### PR TITLE
Initial authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,9 @@ which is built on the tornado ioloop.
 Installation
 ------------
 
-Installing: `pip install asyncmongo`
+Installing form github: `pip install -e git://github.com/patrickod/asyncmongo.git#egg=asyncmongo`
 
-Installing form github: `pip install -e git://github.com/bitly/asyncmongo.git#egg=asyncmongo`
-
-Installing from source: `git clone git://github.com/bitly/asyncmongo.git; cd asyncmongo; python setup.py install`
+Installing from source: `git clone git://github.com/patrickod/asyncmongo.git; cd asyncmongo; python setup.py install`
 
 Usage
 -----
@@ -54,7 +52,7 @@ Features not supported: some features from pymongo are not currently implemented
 interfacing with indexes, dropping collections, and retrieving results in batches instead of all at once. 
 (asyncmongo's nature means that no calls are blocking regardless of the number of results you are retrieving)
 
-Warning: If you need authentication it is advisable to use a fully cached connection pool. As of now when connections are created the first database request will be processed before the authentication callbacks have fully executed. The connection will however be fully created and authenticated and subsequent requests made with that connection will succeed. If someone wants to complete the last mile that would be great. What I have here works for me at the moment. 
+WARNING: If you need authentication it is advisable to use a fully cached connection pool. As of now when connections are created the first database request will be processed before the authentication callbacks have fully executed. The connection will however be fully created and authenticated and subsequent requests made with that connection will succeed. If someone wants to complete the last mile that would be great. What I have here works for me at the moment. 
 
 Requirements
 ------------

--- a/asyncmongo/cursor.py
+++ b/asyncmongo/cursor.py
@@ -373,9 +373,13 @@ class Cursor(object):
             connection.send_message(
                 message.query(self.__query_options(),
                               self.full_collection_name,
-                              self.__skip, self.__limit,
-                              self.__query_spec(), self.__fields), callback=functools.partial(self._handle_response, orig_callback=callback))
-        except:
+                              self.__skip, 
+                              self.__limit,
+                              self.__query_spec(),
+                              self.__fields), 
+                callback=functools.partial(self._handle_response, orig_callback=callback))
+        except Exception as e:
+            print '%s sending failed' % hex(id(self))
             connection.close()
     
     def _handle_response(self, result, error=None, orig_callback=None):

--- a/asyncmongo/cursor.py
+++ b/asyncmongo/cursor.py
@@ -379,7 +379,6 @@ class Cursor(object):
                               self.__fields), 
                 callback=functools.partial(self._handle_response, orig_callback=callback))
         except Exception as e:
-            print '%s sending failed' % hex(id(self))
             connection.close()
     
     def _handle_response(self, result, error=None, orig_callback=None):

--- a/asyncmongo/errors.py
+++ b/asyncmongo/errors.py
@@ -54,3 +54,6 @@ class NotSupportedError(DatabaseError):
 
 class TooManyConnections(Error):
     pass
+
+class AuthenticationError(Error):
+    pass

--- a/asyncmongo/pool.py
+++ b/asyncmongo/pool.py
@@ -100,7 +100,6 @@ class ConnectionPool(object):
         
         # Establish an initial number of idle database connections:
         idle = [self.connection() for i in range(mincached)]
-        print idle
         while idle:
             self.cache(idle.pop())
     
@@ -112,7 +111,6 @@ class ConnectionPool(object):
         # Authenticate if user and pass are set
         if self._dbuser and self._dbpass:
             c = copy.copy(self)
-            print 'in new_connection'
             try:
                 self.conn.send_message(
                         message.query(0,
@@ -123,15 +121,15 @@ class ConnectionPool(object):
                                       SON({})
                             ), callback=c._on_get_nonce)
             except Exception as e:
-                print str(e)
-            print 'sent message'
-        return self.conn
+                # logging.error(str(e))
+            return c.conn
+        else:
+            return self.conn
 
     
     def connection(self):
         """ get a cached connection from the pool """
         
-        print 'in Connection().connection'
         self._condition.acquire()
         try:
             if (self._maxconnections and self._connections >= self._maxconnections):
@@ -186,7 +184,6 @@ class ConnectionPool(object):
             self._condition.release()
     
     def _on_get_nonce(self, response, error=None):
-        print '%s now in get_nonce' % hex(id(self))
         if error:
             raise AuthenticationError(error)
         nonce = response['data'][0]['nonce']
@@ -206,6 +203,5 @@ class ConnectionPool(object):
     def _on_authenticate(self, response, error=None):
         if error:
             raise AuthenticationError(error)
-        print "we are authenticated now"
-        print response
+        self.conn
         

--- a/asyncmongo/pool.py
+++ b/asyncmongo/pool.py
@@ -122,6 +122,7 @@ class ConnectionPool(object):
                             ), callback=c._on_get_nonce)
             except Exception as e:
                 # logging.error(str(e))
+                raise 
             return c.conn
         else:
             return self.conn
@@ -203,5 +204,3 @@ class ConnectionPool(object):
     def _on_authenticate(self, response, error=None):
         if error:
             raise AuthenticationError(error)
-        self.conn
-        

--- a/asyncmongo/pool.py
+++ b/asyncmongo/pool.py
@@ -17,6 +17,7 @@
 from threading import Condition
 import logging
 import hashlib
+import copy
 from bson.son import SON
 from errors import TooManyConnections, ProgrammingError, AuthenticationError
 from connection import Connection
@@ -110,6 +111,7 @@ class ConnectionPool(object):
 
         # Authenticate if user and pass are set
         if self._dbuser and self._dbpass:
+            c = copy.copy(self)
             print 'in new_connection'
             try:
                 self.conn.send_message(
@@ -119,7 +121,7 @@ class ConnectionPool(object):
                                       1,
                                       SON({'getnonce' : 1}),
                                       SON({})
-                            ), callback=self._on_get_nonce)
+                            ), callback=c._on_get_nonce)
             except Exception as e:
                 print str(e)
             print 'sent message'
@@ -184,7 +186,7 @@ class ConnectionPool(object):
             self._condition.release()
     
     def _on_get_nonce(self, response, error=None):
-        print 'now in get_nonce'
+        print '%s now in get_nonce' % hex(id(self))
         if error:
             raise AuthenticationError(error)
         nonce = response['data'][0]['nonce']


### PR DESCRIPTION
These commits add initial authentication support. The 1st request on a given connection will fail as the authentication callbacks have not had time to fully execute. All requests on that connection thereafter however will work. 
