### PR TITLE
Adding support querying slave nodes

### DIFF
--- a/asyncmongo/client.py
+++ b/asyncmongo/client.py
@@ -36,7 +36,7 @@ class Client(object):
       - `**kwargs`: passed to `connection.Connection`
           - `host`: hostname or ip of mongo host
           - `port`: port to connect to
-          - `slave_ok` (optional): is it okay to connect directly to and perform queries on a slave instance
+          - `slave_okay` (optional): is it okay to connect directly to and perform queries on a slave instance
           - `autoreconnect` (optional): auto reconnect on interface errors
     
     @returns a `Client` instance that wraps a `pool.ConnectionPool`

--- a/asyncmongo/connection.py
+++ b/asyncmongo/connection.py
@@ -35,19 +35,16 @@ class Connection(object):
     :Parameters:
       - `host`: hostname or ip of mongo host
       - `port`: port to connect to
-      - `slave_ok` (optional): is it okay to connect directly to and perform queries on a slave instance
       - `autoreconnect` (optional): auto reconnect on interface errors
       
     """
-    def __init__(self, host, port, slave_ok=False, autoreconnect=True, pool=None):
+    def __init__(self, host, port, autoreconnect=True, pool=None):
         assert isinstance(host, (str, unicode))
         assert isinstance(port, int)
-        assert isinstance(slave_ok, bool)
         assert isinstance(autoreconnect, bool)
         assert pool
         self.__host = host
         self.__port = port
-        self.__slave_ok = slave_ok
         self.__stream = None
         self.__callback = None
         self.__alive = False
@@ -158,5 +155,4 @@ class Connection(object):
             return
         # logging.info('response: %s' % response)
         callback(response)
-
 

--- a/asyncmongo/pool.py
+++ b/asyncmongo/pool.py
@@ -66,12 +66,14 @@ class ConnectionPool(object):
                 maxconnections=0, 
                 maxusage=0, 
                 dbname=None, 
+                slave_okay=False, 
                 *args, **kwargs):
         assert isinstance(mincached, int)
         assert isinstance(maxcached, int)
         assert isinstance(maxconnections, int)
         assert isinstance(maxusage, int)
         assert isinstance(dbname, (str, unicode, None.__class__))
+        assert isinstance(slave_okay, bool)
         if mincached and maxcached:
             assert mincached <= maxcached
         if maxconnections:
@@ -85,6 +87,7 @@ class ConnectionPool(object):
         self._idle_cache = [] # the actual connections that can be used
         self._condition = Condition()
         self._dbname = dbname
+        self._slave_okay = slave_okay
         self._connections = 0
         
         # Establish an initial number of idle database connections:
@@ -153,4 +156,14 @@ class ConnectionPool(object):
         finally:
             self._condition.release()
     
+    def __get_slave_okay(self):
+        """Is it OK to perform queries on a secondary or slave?
+        """
+        return self._slave_okay
 
+    def __set_slave_okay(self, value):
+        """Property setter for slave_okay"""
+        assert isinstance(value, bool)
+        self._slave_okay = value
+
+    slave_okay = property(__get_slave_okay, __set_slave_okay)


### PR DESCRIPTION
- Changing kw to slave_okay to match pymongo
- Adding slave_okay kw to Cursor.find
- Adding slave_okay kw to Pool
- Changing Cursor.__get_query_options to check Cursor and Pool
- Removing slave_okay from Connection as it's not used there
