### PR TITLE
kill cursor after a find()

### DIFF
--- a/asyncmongo/cursor.py
+++ b/asyncmongo/cursor.py
@@ -397,6 +397,18 @@ class Cursor(object):
                 orig_callback(result['data'][0], error=None)
             else:
                 orig_callback(result['data'], error=None)
+
+        if result.get('cursor_id'):
+            # logging.debug('killing cursor %s', result['cursor_id'])
+            connection = self.__pool.connection()
+            try:
+                connection.send_message(
+                    message.kill_cursors([result['cursor_id']]),
+                    callback=None)
+            except Exception, e:
+                logging.error('Error killing cursor %s: %s' % (result['cursor_id'], e))
+                connection.close()
+                raise
     
     def __query_options(self):
         """Get the query options string to use for this query."""

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -8,7 +8,7 @@ import pymongo
 
 
 class QueryTest(test_shunt.MongoTest):
-    mongod_options = [('--port', '27999')]
+    mongod_options = [('--port', '27017')]
 
     @property
     def pymongo_conn(self):
@@ -25,7 +25,7 @@ class QueryTest(test_shunt.MongoTest):
         self.pymongo_conn.test.foo.insert([{'i': i} for i in xrange(200)])
 
     def test_query(self):
-        db = asyncmongo.Client(pool_id='test_query', host='127.0.0.1', port=27999, dbname='test', mincached=3)
+        db = asyncmongo.Client(pool_id='test_query', host='127.0.0.1', port=int(self.mongod_options[0][1]), dbname='test', mincached=3)
 
         def noop_callback(response, error):
             tornado.ioloop.IOLoop.instance().stop()

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -1,0 +1,41 @@
+import tornado.ioloop
+import logging
+import time
+
+import test_shunt
+import asyncmongo
+import pymongo
+
+
+class QueryTest(test_shunt.MongoTest):
+    mongod_options = [('--port', '27999')]
+
+    @property
+    def pymongo_conn(self):
+        if not hasattr(self, '_pymongo_conn'):
+            self._pymongo_conn = pymongo.Connection(port=int(self.mongod_options[0][1]))
+        return self._pymongo_conn
+
+    def get_open_cursors(self):
+        output = self.pymongo_conn.admin.command('serverStatus')
+        return output.get('cursors', {}).get('totalOpen')
+
+    def setUp(self):
+        super(QueryTest, self).setUp()
+        self.pymongo_conn.test.foo.insert([{'i': i} for i in xrange(200)])
+
+    def test_query(self):
+        db = asyncmongo.Client(pool_id='test_query', host='127.0.0.1', port=27999, dbname='test', mincached=3)
+
+        def noop_callback(response, error):
+            tornado.ioloop.IOLoop.instance().stop()
+
+        before = self.get_open_cursors()
+        db.foo.find(limit=20, callback=noop_callback)
+        tornado.ioloop.IOLoop.instance().start()
+        after = self.get_open_cursors()
+        self.assertEquals(before, after, "%d cursors left open (should be 0)" % (after - before))
+
+if __name__ == '__main__':
+    import unittest
+    unittest.main()


### PR DESCRIPTION
If no limit was specified in a `find()`, then the cursor will remain open on the server until mongod kills it (by default, after 10 minutes). Patch sends an `OP_KILL_CURSORS` (http://www.mongodb.org/display/DOCS/Mongo+Wire+Protocol#MongoWireProtocol-OPKILLCURSORS) after the callback if there was a (non-zero) cursor id in the response.
