### PR TITLE
Add asyncmongo.backends to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
     ],
-    packages=['asyncmongo'],
+    packages=['asyncmongo', 'asyncmongo.backends'],
     install_requires=['pymongo>=1.9', 'tornado'],
     requires=['pymongo (>=1.9)', 'tornado'],
     download_url="http://github.com/downloads/bitly/asyncmongo/asyncmongo-%s.tar.gz" % version,


### PR DESCRIPTION
Added asyncmongo.backends to the packages list, otherwise it won't be installed by distutils.
