### PR TITLE
Give the ability to pass arguments to the backend

### DIFF
--- a/asyncmongo/backends/glib2_backend.py
+++ b/asyncmongo/backends/glib2_backend.py
@@ -17,7 +17,7 @@
 import glib
 
 class Glib2Stream(object):
-    def __init__(self, socket):
+    def __init__(self, socket, **kwargs):
         self.__socket = socket
         self.__close_id = None
         self.__read_id = None
@@ -81,5 +81,5 @@ class AsyncBackend(object):
                 cls, *args, **kwargs)
         return cls._instance
 
-    def register_stream(self, socket):
-        return Glib2Stream(socket)
+    def register_stream(self, socket, **kwargs):
+        return Glib2Stream(socket, **kwargs)

--- a/asyncmongo/backends/glib3_backend.py
+++ b/asyncmongo/backends/glib3_backend.py
@@ -17,7 +17,7 @@
 from gi.repository import GObject
 
 class Glib3Stream(object):
-    def __init__(self, socket):
+    def __init__(self, socket, **kwargs):
         self.__socket = socket
         self.__close_id = None
         self.__read_id = None
@@ -81,5 +81,5 @@ class AsyncBackend(object):
                 cls, *args, **kwargs)
         return cls._instance
 
-    def register_stream(self, socket):
-        return Glib3Stream(socket)
+    def register_stream(self, socket, **kwargs):
+        return Glib3Stream(socket, **kwargs)

--- a/asyncmongo/backends/tornado_backend.py
+++ b/asyncmongo/backends/tornado_backend.py
@@ -17,8 +17,16 @@
 import tornado.iostream
 
 class TornadoStream(object):
-    def __init__(self, socket):
-        self.__stream = tornado.iostream.IOStream(socket)
+    def __init__(self, socket, **kwargs):
+        """
+        :Parameters:
+          - `socket`: TCP socket
+          - `**kwargs`: passed to `tornado.iostream.IOStream`
+            - `io_loop` (optional): Tornado IOLoop instance.
+            - `max_buffer_size` (optional):
+            - `read_chunk_size` (optional):
+        """
+        self.__stream = tornado.iostream.IOStream(socket, **kwargs)
 
     def write(self, data):
         self.__stream.write(data)
@@ -41,6 +49,13 @@ class AsyncBackend(object):
                 cls, *args, **kwargs)
         return cls._instance
 
-    def register_stream(self, socket):
-        return TornadoStream(socket)
-        
+    def register_stream(self, socket, **kwargs):
+        """
+        :Parameters:
+          - `socket`: TCP socket
+          - `**kwargs`: passed to `tornado.iostream.IOStream`
+            - `io_loop` (optional): Tornado IOLoop instance.
+            - `max_buffer_size` (optional):
+            - `read_chunk_size` (optional):
+        """
+        return TornadoStream(socket, **kwargs)

--- a/asyncmongo/connection.py
+++ b/asyncmongo/connection.py
@@ -40,15 +40,17 @@ class Connection(object):
       - `dbuser`: db user to connect with
       - `dbpass`: db password
       - `autoreconnect` (optional): auto reconnect on interface errors
+      - `**kwargs`: passed to `backends.AsyncBackend.register_stream`
       
     """
     def __init__(self, host, port, dbuser=None, dbpass=None, autoreconnect=True, pool=None,
-                 backend="tornado"):
+                 backend="tornado", **kwargs):
         assert isinstance(host, (str, unicode))
         assert isinstance(port, int)
         assert isinstance(autoreconnect, bool)
         assert isinstance(dbuser, (str, unicode, None.__class__))
         assert isinstance(dbpass, (str, unicode, None.__class__))
+        assert isinstance(kwargs, (dict, None.__class__))
         assert pool
         self.__host = host
         self.__port = port
@@ -62,6 +64,7 @@ class Connection(object):
         self.__pool = pool
         self.__deferred_message = None
         self.__deferred_callback = None
+        self.__kwargs = kwargs
         self.__backend = self.__load_backend(backend)
         self.usage_count = 0
         self.__connect()
@@ -76,7 +79,7 @@ class Connection(object):
         try:
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
             s.connect((self.__host, self.__port))
-            self.__stream = self.__backend.register_stream(s)
+            self.__stream = self.__backend.register_stream(s, **self.__kwargs)
             self.__stream.set_close_callback(self._socket_close)
             self.__alive = True
         except socket.error, error:
@@ -238,5 +241,3 @@ class Connection(object):
                               SON({'getnonce' : 1}),
                               SON({})
                     ))
-    
-


### PR DESCRIPTION
The current backend interface doesn't have anyway for the user to pass arguments to it. At least in the tornado backend, sometime it's needed to pass the IOLoop instance to the IOStream. 

For example:

``` python
from tornado.testing import AsyncTestCase
import asyncmongo

class AsyncTest(AsyncTestCase):
    def test_insert(self):
        db = asyncmongo.Client(pool_id='testinsert', host='127.0.0.1', port=27017, dbname='test')
        db.test_users.insert({"one" : 1}, callback=self.insert_callback)
        self.wait()

    def insert_callback(self, response, error=None):
        self.assertEqual(1, 1)
        self.stop()
```

will hang forever because IOStream created another IOLoop instance different from the unittest IOLoop instance.

But with this update, it can be fixed by connecting using

``` python
db = asyncmongo.Client(pool_id='testinsert', host='127.0.0.1', port=27017, dbname='test', io_loop=self.io_loop)
```

BTW, I have not test this with GLib backend.
