### PR TITLE
Non-Blocking Connection and Timeout Support [rebase on master]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
+*.pyo
 build
 dist
+tags

--- a/asyncmongo/backends/tornado_backend.py
+++ b/asyncmongo/backends/tornado_backend.py
@@ -28,6 +28,13 @@ class TornadoStream(object):
         """
         self.__stream = tornado.iostream.IOStream(socket, **kwargs)
 
+    @property
+    def io_loop(self):
+        return self.__stream.io_loop
+
+    def connect(self, address, callback=None):
+        self.__stream.connect(address, callback)
+
     def write(self, data):
         self.__stream.write(data)
     

--- a/asyncmongo/connection.py
+++ b/asyncmongo/connection.py
@@ -57,8 +57,6 @@ class Connection(object):
                  connect_timeout=20.0,
                  request_timeout=20.0,
                  **kwargs):
-        assert isinstance(host, (str, unicode))
-        assert isinstance(port, int)
         assert isinstance(autoreconnect, bool)
         assert isinstance(dbuser, (str, unicode, NoneType))
         assert isinstance(dbpass, (str, unicode, NoneType))

--- a/asyncmongo/connection.py
+++ b/asyncmongo/connection.py
@@ -134,9 +134,6 @@ class Connection(object):
         except socket.error, error:
             raise InterfaceError(error)
         
-        if self.__dbuser and self.__dbpass:
-            self.__authenticate = True
-
     def _on_timeout(self):
         self.__timeout = None
         self.close()


### PR DESCRIPTION
**Issue**
The Blocking IO Connection will causing that the tornado service can not respond new HTTP Request,  when MongoDB server goes down(Error: no route to host). 

**New Feature**
create Non-blocking connection to mongodb service, support for connection timeout and request timeout, when using tornado as the Async Backend

**Refrence From**
Inspiration from [tornado.simple_httpclient._HTTPConnection](https://github.com/facebook/tornado/blob/branch2.3/tornado/simple_httpclient.py)
