### PR TITLE
Non-Blocking Connection and Timeout Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
+*.pyo
 build
 dist
+tags

--- a/asyncmongo/backends/tornado_backend.py
+++ b/asyncmongo/backends/tornado_backend.py
@@ -28,6 +28,13 @@ class TornadoStream(object):
         """
         self.__stream = tornado.iostream.IOStream(socket, **kwargs)
 
+    @property
+    def io_loop(self):
+        return self.__stream.io_loop
+
+    def connect(self, address, callback=None):
+        self.__stream.connect(address, callback)
+
     def write(self, data):
         self.__stream.write(data)
     

--- a/asyncmongo/connection.py
+++ b/asyncmongo/connection.py
@@ -140,7 +140,6 @@ class Connection(object):
 
     def _on_connect(self):
         if self.__timeout is not None:
-            #self.__timeout.callback = None
             self.__stream.io_loop.remove_timeout(self.__timeout)
             self.__timeout = None
 
@@ -221,6 +220,10 @@ class Connection(object):
         # return self.__request_id 
     
     def _parse_header(self, header):
+        if self.__timeout is not None:
+            self.__stream.io_loop.remove_timeout(self.__timeout)
+            self.__timeout = None
+
         # return self.__receive_data_on_socket(length - 16, sock)
         length = int(struct.unpack("<i", header[:4])[0])
         request_id = struct.unpack("<i", header[8:12])[0]

--- a/asyncmongo/connection.py
+++ b/asyncmongo/connection.py
@@ -80,7 +80,7 @@ class Connection(object):
             assert seed is None
         
         assert connect_timeout > 0
-        assert isinstance(request_timeout, (float, int, NoneType)
+        assert isinstance(request_timeout, (float, int, NoneType))
 
         self._host = host
         self._port = port

--- a/asyncmongo/connection.py
+++ b/asyncmongo/connection.py
@@ -103,7 +103,6 @@ class Connection(object):
         self.__min_timeout = min(connect_timeout, request_timeout)
         self.__life_time = life_time
         self.__timeout = None
-        self.__start_time = time.time()
         self.__connect()
 
     def __load_backend(self, name):
@@ -112,6 +111,8 @@ class Connection(object):
         return mod.AsyncBackend()
     
     def __connect(self):
+        self.__start_time = time.time()
+
         if self.__dbuser and self.__dbpass:
             self._put_job(asyncjobs.AuthorizeJob(self, self.__dbuser, self.__dbpass, self.__pool))
 


### PR DESCRIPTION
**Issue**
- The Blocking IO Connection will causing that the tornado service can not respond new HTTP Request,  when MongoDB server goes down(Error: no route to host). 

**New Feature**
- create Non-blocking connection to mongodb service, support for connection timeout and request timeout, when using tornado as the Async Backend
- add life time for long connection

**Refrence**
- Inspiration from [tornado.simple_httpclient._HTTPConnection](https://github.com/facebook/tornado/blob/branch2.3/tornado/simple_httpclient.py)
